### PR TITLE
Add support with interacting with asynchronous operations.

### DIFF
--- a/Monads/Either.cs
+++ b/Monads/Either.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace UsefulMonads.Either
 {
@@ -158,6 +159,27 @@ namespace UsefulMonads.Either
       return isError ?
         new Either<TError, TMapped>(Failure.Value) :
         mapSucceeded(Ok.Value);
+    }
+
+    /// <summary>
+    /// Asynchronously transfer the inner <typeparamref name="TOk"/> value a new <see cref="Either{TError,TOk}"/> value.
+    /// </summary>
+    /// <typeparam name="TMapped">The return type of the new inner transformed value.</typeparam>
+    /// <param name="mapSucceeded">This callback is invoked if the wrapped value is a <typeparamref name="TOk"/> value. Must not be null.</param>
+    /// <returns>A new <see cref="Task"/> containing the transformed value.</returns>
+    public async Task<Either<TError, TMapped>> BindAsync<TMapped>(Func<TOk, Task<Either<TError, TMapped>>> mapSucceeded)
+    {
+      if (mapSucceeded == null)
+      {
+        throw new ArgumentNullException(nameof(mapSucceeded));
+      }
+
+      if (isError)
+      {
+        return new Either<TError, TMapped>(Failure.Value);
+      }
+
+      return await mapSucceeded(Ok.Value);
     }
 
     /// <summary>

--- a/Monads/EitherExtensions.cs
+++ b/Monads/EitherExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace UsefulMonads.Either
 {
@@ -36,6 +37,28 @@ namespace UsefulMonads.Either
       }
 
       return source.MapOk(selector);
+    }
+
+    /// <summary>
+    /// Select wrapper for LINQ query syntax.
+    /// </summary>
+    /// <typeparam name="TError">The 'left' type of the <see cref="Either{TError,TOk}"/>.</typeparam>
+    /// <typeparam name="TOk">The 'right' type of the <see cref="Either{TError,TOk}"/>.</typeparam>
+    /// <typeparam name="TMapped">The type of the transformed value.</typeparam>
+    /// <param name="source">An instance of a <see cref="Task"/> containing a <see cref="Either{TError,TOk}"/>.</param>
+    /// <param name="selector">A callback which will be called with the wrapped <typeparamref name="TOk"/> value,
+    /// if the wrapped value is of that type. Must not be null.</param>
+    /// <returns>A new <see cref="Task"/> containing a <see cref="Either{TError,TOk}"/> instance where the <typeparamref name="TOk"/>
+    /// value has been mapped to a <typeparamref name="TMapped"/> by the <paramref name="selector"/> function.</returns>
+    public static async Task<Either<TError, TMapped>> Select<TError, TOk, TMapped>(this Task<Either<TError, TOk>> source, Func<TOk, TMapped> selector)
+    {
+      if (selector == null)
+      {
+        throw new ArgumentNullException(nameof(selector));
+      }
+
+      return await (await source)
+        .BindAsync(ok => Task.FromResult(new Either<TError, TMapped>(selector(ok))));
     }
 
     /// <summary>
@@ -96,6 +119,28 @@ namespace UsefulMonads.Either
       return source
         .Bind(x => eitherSelector(x)
         .Bind(y => new Either<TError, TResult>(resultSelector(x, y))));
+    }
+
+    /// <summary>
+    /// SelectMany wrapper for LINQ query syntax supporting asynchronous operations, which is a better fit for things like API interactions.
+    /// </summary>
+    /// <typeparam name="TError">The 'left' type of the <see cref="Either{TError,TOk}"/>.</typeparam>
+    /// <typeparam name="TOk">The 'right' type of the <see cref="Either{TError,TOk}"/>.</typeparam>
+    /// <typeparam name="TMapped">The type of the transformed value.</typeparam>
+    /// <typeparam name="TResult">The 'right' type inside the returned <see cref="Task"/> containing a <see cref="Either{TError,TResult}"/>.</typeparam>
+    /// <param name="source">An instance of a <see cref="Task"/> containing a <see cref="Either{TError,TOk}"/>. </param>
+    /// <param name="eitherSelector">Callback that will be invoked with the inner <typeparamref name="TOk"/> value and maps it
+    /// to a <typeparamref name="TMapped"/> value. Must not be null.</param>
+    /// <param name="resultSelector">An analogous version of the non-<see cref="Task"/> based version, see <see cref="SelectMany{TError,TOk,TMapped}"/>.</param>
+    /// <returns>A new <see cref="Task"/> containing <see cref="Either{TError,TOk}"/> with the 'combined' value.</returns>
+    public static async Task<Either<TError, TResult>> SelectMany<TError, TOk, TMapped, TResult>(
+      this Task<Either<TError, TOk>> source,
+      Func<TOk, Task<Either<TError, TMapped>>> eitherSelector,
+      Func<TOk, TMapped, TResult> resultSelector)
+    {
+      return await (await source)
+        .BindAsync(async x => await (await eitherSelector(x))
+        .BindAsync(y =>Task.FromResult(new Either<TError, TResult>(resultSelector(x, y)))));
     }
   }
 }

--- a/Tests/EitherTests.cs
+++ b/Tests/EitherTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Reflection.Metadata.Ecma335;
+using System.Threading.Tasks;
 using FluentAssertions;
 using UsefulMonads.Either;
 using Xunit;
@@ -106,6 +108,32 @@ namespace Tests
         from r in sut2
         select s * r;
       q.Resolve(s => s.Length, i => i).Should().Be(126);
+    }
+
+    async Task<Either<bool, string>> GetSut(int delay)
+    {
+      var sut = new Either<bool, string>("AsyncValue ");
+      await Task.Delay(delay);
+      return sut;
+    }
+
+    [Fact]
+    public async Task TestAsyncSelect()
+    {
+      var q = from b1 in GetSut(10) select b1;
+      var result = await q;
+      result.Resolve(s => "", s => s).Should().Be("AsyncValue ");
+    }
+
+    [Fact]
+    public async Task TestAsyncSelectMany()
+    {
+      var q =
+        from b1 in GetSut(10)
+        from b2 in GetSut(10)
+        select b1 + b2;
+      var result = await q;
+      result.Resolve(s => "", s => s).Should().Be("AsyncValue AsyncValue ");
     }
 
   }


### PR DESCRIPTION
Fixes #5 

An often encountered use case would be to use an Either value to model the response from and API. These are often async, so the Either class should be able to 'play nice' with Task based programming